### PR TITLE
Add router and tests for custom model.

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,3 +3,4 @@ exports.TEST_DATABASE_URL = process.env.TEST_DATABASE_URL || 'mongodb://localhos
 exports.NODE_ENV = process.env.NODE_ENV || 'production';
 exports.PORT = process.env.PORT || 8080;
 exports.HACKER_NEWS_API = 'https://hacker-news.firebaseio.com/v0/item/';
+exports.CUSTOM_MODEL_ADDRESS = 'http://35.226.186.209:8501/v1/models/sentiment:predict';

--- a/customModelThreads/index.js
+++ b/customModelThreads/index.js
@@ -1,0 +1,8 @@
+const { CustomThread } = require('./models');
+const {
+  router, mean, wordCount, addSentimentAnalysis, getKids,
+} = require('./router');
+
+module.exports = {
+  CustomThread, router, mean, wordCount, addSentimentAnalysis, getKids,
+};

--- a/customModelThreads/models.js
+++ b/customModelThreads/models.js
@@ -1,0 +1,63 @@
+const mongoose = require('mongoose');
+
+mongoose.Promise = global.Promise;
+
+
+const CustomChildSchema = mongoose.Schema({
+  _id: false,
+  id: { type: Number, required: true },
+  by: { type: String },
+  kids: { type: Array },
+  type: { type: String },
+  text: { type: String },
+  time: { type: Number },
+  wordCount: { type: Number },
+  documentSentiment: {
+    score: { type: Number },
+    magnitude: { type: Number },
+  },
+});
+
+const CustomThreadSchema = mongoose.Schema(
+  {
+    id: { type: Number, required: true },
+    by: { type: String },
+    descendants: { type: String },
+    score: { type: Number },
+    time: { type: Number },
+    title: { type: String },
+    text: { type: String },
+    type: { type: String },
+    url: { type: String },
+    avgWordCount: { type: Number, default: 0.0 },
+    avgSentiment: { type: Number, default: 0.0 },
+    avgMagnitude: { type: Number, default: 0.0 },
+    kids: [CustomChildSchema],
+  },
+  { timestamps: { updatedAt: 'lastUpdated' } },
+);
+
+CustomThreadSchema.methods.serialize = function () {
+  return {
+    id: this.id,
+    lastUpdated: this.lastUpdated,
+    documentSentiment: this.documentSentiment,
+    avgWordCount: this.avgWordCount,
+    avgSentiment: this.avgSentiment,
+    avgMagnitude: this.avgMagnitude,
+    kids: this.kids,
+    by: this.by,
+    descendants: this.descendants,
+    score: this.score,
+    time: this.time,
+    type: this.type,
+    title: this.title,
+    text: this.text,
+    url: this.url,
+  };
+};
+
+
+const CustomThread = mongoose.model('CustomModelThread', CustomThreadSchema);
+
+module.exports = { CustomThread };

--- a/customModelThreads/router.js
+++ b/customModelThreads/router.js
@@ -1,0 +1,111 @@
+const axios = require('axios');
+const express = require('express');
+const { CustomThread } = require('./models');
+const { HACKER_NEWS_API, NODE_ENV, CUSTOM_MODEL_ADDRESS } = require('../config');
+
+const router = express.Router();
+
+const mean = arr => arr.reduce((p, c) => p + c, 0) / arr.length;
+const wordCount = (someString) => {
+  if (!someString) {
+    return 0;
+  }
+  return someString.trim().split(/\s+/).length;
+};
+
+const hnRequest = (itemId) => {
+  return axios.get(`${HACKER_NEWS_API}${itemId}.json`);
+};
+
+const addSentimentAnalysis = async (kid, nodeEnv = NODE_ENV) => {
+  kid.wordCount = wordCount(kid.text);
+  if (nodeEnv === 'test') {
+    kid.documentSentiment = {
+      score: Math.random(),
+      magnitude: Math.random() * 100,
+    };
+    return kid;
+  }
+  // Otherwise, we are in prod, make a real request.
+  data = {
+    instances: [kid.text],
+  };
+  const response = await axios.post(CUSTOM_MODEL_ADDRESS, data);
+  const sentiment = response.data.predictions[0].scores[1]
+  kid.documentSentiment = {
+    score: sentiment,
+    magnitude: null,
+  };
+  return kid;
+};
+
+const getKids = async (kidIds) => {
+  let kids = (await axios.all(kidIds.map(hnRequest))).map(k => k.data);
+  // Keep only kids with text.
+  kids = kids.filter(k => k.text);
+  const kidsWithSentiments = await Promise.all(kids.map(async (kid) => {
+    const sentiment = await addSentimentAnalysis(kid);
+    return sentiment;
+  }));
+  return kidsWithSentiments;
+};
+
+const addThread = async (threadId) => {
+  const parent = await hnRequest(threadId);
+  const threadData = parent.data;
+  if (threadData.kids) {
+    // Replace array of thread Id's with an array of objects from HN News API.
+    const kids = await getKids(threadData.kids);
+    threadData.kids = kids;
+    threadData.avgWordCount = mean(kids.map(kid => kid.wordCount));
+    threadData.avgSentiment = mean(kids.map(kid => kid.documentSentiment.score));
+    threadData.avgMagnitude = mean(kids.map(kid => kid.documentSentiment.magnitude));
+  }
+  return CustomThread.create(threadData);
+};
+
+
+const updateThread = async (thread) => {
+  const updatedKidIds = (await hnRequest(thread.id)).data.kids;
+  const existingKidIds = thread.kids.map(kid => kid.id);
+  const missingKidIds = updatedKidIds.filter(id => existingKidIds.indexOf(id) === -1);
+  if (!missingKidIds) {
+    return thread;
+  }
+  // Get missing comments, append to existing kids, then update record.
+  const missingKids = await getKids(missingKidIds);
+  thread.kids = thread.kids.concat(missingKids);
+  return CustomThread.findOneAndUpdate(
+    { id: thread.id },
+    { $set: { kids: thread.kids } },
+    { new: true },
+  );
+};
+
+router.get('/:id', async (req, res) => {
+  const { id } = req.params;
+  const isNumber = /^\d+$/.test(id);
+  if (!isNumber) {
+    res.status(500).json({ error: 'Thread id must be an integer.' });
+    return;
+  }
+  try {
+    let thread = await CustomThread.findOne({ id });
+    if (!thread) {
+      thread = await addThread(id);
+    }
+    if ((new Date() - thread.lastUpdated) > 60000) {
+      thread = await updateThread(thread);
+    }
+    res.json(thread.serialize());
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'something went wrong' });
+  }
+});
+
+
+module.exports = {
+  router, mean, wordCount, addSentimentAnalysis, getKids,
+};
+

--- a/test/test-custom-threads.js
+++ b/test/test-custom-threads.js
@@ -4,7 +4,7 @@ const faker = require('faker');
 const chai = require('chai');
 const chaiHttp = require('chai-http');
 const { app, runServer, closeServer } = require('../index');
-const { Thread, mean, wordCount } = require('../threads');
+const { CustomThread, mean, wordCount } = require('../customModelThreads');
 const { TEST_DATABASE_URL } = require('../config');
 
 process.env.NODE_ENV = 'test';
@@ -54,19 +54,19 @@ function seedCollection() {
     lastUpdated: new Date(1900),
   };
   // this will return a promise
-  return Thread.insertMany([seedThread1, seedThread2]);
+  return CustomThread.insertMany([seedThread1, seedThread2]);
 }
 
 
 function clearCollection() {
   return new Promise((resolve, reject) => {
-    Thread.deleteMany({})
+    CustomThread.deleteMany({})
       .then(result => resolve(result))
       .catch(err => reject(err));
   });
 }
 
-describe('/api/threads/gcp', function () {
+describe('/api/threads/custom', function () {
   before(function () {
     return runServer(TEST_DATABASE_URL);
   });
@@ -85,7 +85,7 @@ describe('/api/threads/gcp', function () {
 
   it('should 200 on GET requests for IDs in the db', async function () {
     this.timeout(5000);
-    const res = await chai.request(app).get('/api/threads/gcp/0');
+    const res = await chai.request(app).get('/api/threads/custom/0');
     res.should.have.status(200);
     res.should.be.json;
     const expectedKeys = [
@@ -104,13 +104,13 @@ describe('/api/threads/gcp', function () {
 
   it('should Update threads older than 1 min', async function () {
     this.timeout(5000);
-    const res = await chai.request(app).get('/api/threads/gcp/8863');
+    const res = await chai.request(app).get('/api/threads/custom/8863');
     res.body.kids.length.should.be.at.least(32);
   });
 
   it('should 500 on GET requests for invalid IDs ', async function () {
     this.timeout(5000);
-    const res = await chai.request(app).get('/api/threads/gcp/XXXX');
+    const res = await chai.request(app).get('/api/threads/custom/XXXX');
     res.should.have.status(500);
   });
 });

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -20,8 +20,14 @@ describe('High level server tests', function () {
     return closeServer();
   });
 
-  it('should 200 on GET /threads/recent', async function () {
-    const res = await chai.request(app).get('/api/threads/recent');
+  it('should 200 on GET /threads/gcp/recent', async function () {
+    const res = await chai.request(app).get('/api/threads/gcp/recent');
+    res.should.have.status(200);
+    res.should.be.json;
+  });
+
+  it('should 200 on GET /threads/custom/recent', async function () {
+    const res = await chai.request(app).get('/api/threads/custom/recent');
     res.should.have.status(200);
     res.should.be.json;
   });


### PR DESCRIPTION
This PR adds new paths to the API which send sentiment classification requests to a custom model hosted on GCP instead of the GCP NLP API. 

/api/threads/recent -> /api/threads/gcp/recent or /api/threads/custom/recent
